### PR TITLE
Teemow add license change default por

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 - 2025 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For detailed instructions on modes, flags, and examples, please see the full usa
 
 **Connect to a server and listen for notifications:**
 ```bash
-./mcp-debug --endpoint http://localhost:8899/mcp
+./mcp-debug --endpoint http://localhost:8090/mcp
 ```
 
 **Start the interactive REPL:**

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ In MCP Server mode:
 - It's designed for integration with AI assistants like Claude or Cursor
 - Configure it in your AI assistant's MCP settings
 
-By default, it connects to http://localhost:8899/mcp. You can override this with the --endpoint flag.`,
+By default, it connects to http://localhost:8090/mcp. You can override this with the --endpoint flag.`,
 	RunE: runMCPDebug,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func SetVersion(v string) {
 
 func init() {
 	// Add flags
-	rootCmd.Flags().StringVar(&endpoint, "endpoint", "http://localhost:8899/mcp", "MCP endpoint URL (must end with /mcp for streamable-http)")
+	rootCmd.Flags().StringVar(&endpoint, "endpoint", "http://localhost:8090/mcp", "MCP endpoint URL (must end with /mcp for streamable-http)")
 	rootCmd.Flags().StringVar(&transport, "transport", "streamable-http", "Transport protocol to use for client connections (streamable-http, sse)")
 	rootCmd.Flags().StringVar(&serverTransport, "server-transport", "stdio", "Transport protocol for the MCP server itself (stdio, streamable-http)")
 	rootCmd.Flags().StringVar(&listenAddr, "listen-addr", ":8899", "Listen address for streamable-http server (path is fixed to /mcp)")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,17 +6,21 @@ This guide covers the main functionalities and how to use them.
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Modes of Operation](#modes-of-operation)
-  - [1. Normal Mode (Passive Listening)](#1-normal-mode-passive-listening)
-  - [2. REPL Mode (Interactive Debugging)](#2-repl-mode-interactive-debugging)
-  - [3. MCP Server Mode (AI Assistant Integration)](#3-mcp-server-mode-ai-assistant-integration)
-- [Transport Protocols](#transport-protocols)
-- [Command-Line Flags](#command-line-flags)
-- [Usage Examples](#usage-examples)
-  - [Connecting to a Server](#connecting-to-a-server)
-  - [Using the REPL](#using-the-repl)
-  - [Running as an MCP Server](#running-as-an-mcp-server)
+- [Using mcp-debug](#using-mcp-debug)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [1. Pre-built Binaries (Recommended)](#1-pre-built-binaries-recommended)
+    - [2. Build from Source](#2-build-from-source)
+  - [Modes of Operation](#modes-of-operation)
+    - [1. Normal Mode (Passive Listening)](#1-normal-mode-passive-listening)
+    - [2. REPL Mode (Interactive Debugging)](#2-repl-mode-interactive-debugging)
+    - [3. MCP Server Mode (AI Assistant Integration)](#3-mcp-server-mode-ai-assistant-integration)
+  - [Transport Protocols](#transport-protocols)
+  - [Command-Line Flags](#command-line-flags)
+  - [Usage Examples](#usage-examples)
+    - [Connecting to a Server](#connecting-to-a-server)
+    - [Using the REPL](#using-the-repl)
+    - [Running as an MCP Server](#running-as-an-mcp-server)
 
 ---
 
@@ -80,7 +84,7 @@ This is the default mode. The tool connects to an MCP server, logs any notificat
 ```bash
 ./mcp-debug --endpoint <server-url>
 ```
-By default, it connects to `http://localhost:8899/mcp` and waits for 5 minutes.
+By default, it connects to `http://localhost:8090/mcp` and waits for 5 minutes.
 
 ### 2. REPL Mode (Interactive Debugging)
 
@@ -162,7 +166,7 @@ Here are the most important flags to configure `mcp-debug`:
 | ------------------- | ------------------------------------------------------------------------------------ | ------------------------------ |
 | `--repl`            | Start the interactive REPL mode.                                                     | `false`                        |
 | `--mcp-server`      | Run as an MCP server.                                                                | `false`                        |
-| `--endpoint`        | The URL of the target MCP server.                                                    | `http://localhost:8899/mcp`    |
+| `--endpoint`        | The URL of the target MCP server.                                                    | `http://localhost:8090/mcp`    |
 | `--transport`       | Client transport protocol (`streamable-http`, `sse`).                                | `streamable-http`              |
 | `--server-transport`| Server transport protocol (`stdio`, `streamable-http`).                                | `stdio`                        |
 | `--listen-addr`     | Listen address for the `streamable-http` server.                                     | `:8899`                        |

--- a/mcp.json.example
+++ b/mcp.json.example
@@ -2,7 +2,7 @@
     "mcpServers": {
         "mcp-debug": {
             "command": "mcp-debug",
-            "args": ["--mcp-server", "--endpoint", "http://localhost:8090/sse"]
+            "args": ["--mcp-server", "--endpoint", "http://localhost:8090/mcp"]
         }
     }
 } 


### PR DESCRIPTION
This pull request introduces a new Apache 2.0 license for the project and updates the default MCP server endpoint URL across multiple files for consistency. Additionally, minor documentation improvements were made to enhance usability.

### Licensing:
* Added an Apache License 2.0 to the project, defining terms for use, distribution, and contributions. (`LICENSE`)

### Endpoint Updates:
* Changed the default MCP server endpoint URL from `http://localhost:8899/mcp` to `http://localhost:8090/mcp` in the following files:
  - `README.md`
  - `cmd/root.go` [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL65-R65) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL85-R85)
  - `docs/usage.md` [[1]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L83-R87) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L165-R169)
  - `mcp.json.example`

### Documentation Enhancements:
* Added a detailed table of contents to improve navigation in `docs/usage.md`.