### PR TITLE
fix(oauth): remove default MCP scopes, make scopes optional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&oauthEnabled, "oauth", false, "Enable OAuth authentication for connecting to protected MCP servers")
 	rootCmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth client ID (optional - will use Dynamic Client Registration if not provided)")
 	rootCmd.Flags().StringVar(&oauthClientSecret, "oauth-client-secret", "", "OAuth client secret (optional)")
-	rootCmd.Flags().StringSliceVar(&oauthScopes, "oauth-scopes", []string{"mcp:tools", "mcp:resources"}, "OAuth scopes to request")
+	rootCmd.Flags().StringSliceVar(&oauthScopes, "oauth-scopes", []string{}, "OAuth scopes to request (optional)")
 	rootCmd.Flags().StringVar(&oauthRedirectURL, "oauth-redirect-url", "http://localhost:8765/callback", "OAuth redirect URL for callback")
 	rootCmd.Flags().BoolVar(&oauthUsePKCE, "oauth-pkce", true, "Use PKCE (Proof Key for Code Exchange) for OAuth flow")
 	rootCmd.Flags().DurationVar(&oauthTimeout, "oauth-timeout", 5*time.Minute, "Maximum time to wait for OAuth authorization")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -216,7 +216,7 @@ The tool will automatically register itself with the authorization server and ob
 | `--oauth` | Enable OAuth authentication | `false` |
 | `--oauth-client-id` | OAuth client ID (optional - uses DCR if not provided) | |
 | `--oauth-client-secret` | OAuth client secret (optional) | |
-| `--oauth-scopes` | OAuth scopes to request (comma-separated) | `mcp:tools,mcp:resources` |
+| `--oauth-scopes` | OAuth scopes to request (comma-separated, optional) | (none) |
 | `--oauth-redirect-url` | Redirect URL for OAuth callback | `http://localhost:8765/callback` |
 | `--oauth-pkce` | Use PKCE for authorization | `true` |
 | `--oauth-timeout` | Maximum time to wait for OAuth authorization | `5m` |
@@ -352,12 +352,16 @@ If the server doesn't support DCR and you can't register your own application, c
 
 ### Understanding OAuth Scopes
 
-**Important:** The scopes you specify with `--oauth-scopes` are for the **MCP server**, not for the underlying service provider (like Google).
+**Important:** OAuth scopes are **optional**. By default, no scopes are sent. The scopes you specify with `--oauth-scopes` are for the **MCP server**, not for the underlying service provider (like Google).
 
-**Correct Scope Usage:**
+**Scope Usage:**
 
 ```bash
-# ✅ Correct: Requesting MCP server scopes
+# ✅ Correct: No scopes (default)
+./mcp-debug --oauth \
+  --endpoint https://mcp-server-for-google.com/mcp
+
+# ✅ Correct: Requesting specific MCP server scopes
 ./mcp-debug --oauth \
   --oauth-scopes "mcp:tools,mcp:resources" \
   --endpoint https://mcp-server-for-google.com/mcp

--- a/internal/agent/oauth_config.go
+++ b/internal/agent/oauth_config.go
@@ -17,7 +17,7 @@ type OAuthConfig struct {
 	// ClientSecret is the OAuth client secret (optional for public clients)
 	ClientSecret string
 
-	// Scopes are the OAuth scopes to request (default: mcp:tools, mcp:resources)
+	// Scopes are the OAuth scopes to request (optional, no default scopes)
 	Scopes []string
 
 	// RedirectURL is the callback URL for OAuth flow (default: http://localhost:8765/callback)
@@ -37,7 +37,7 @@ type OAuthConfig struct {
 func DefaultOAuthConfig() *OAuthConfig {
 	return &OAuthConfig{
 		Enabled:              false,
-		Scopes:               []string{"mcp:tools", "mcp:resources"},
+		Scopes:               []string{},
 		RedirectURL:          "http://localhost:8765/callback",
 		UsePKCE:              true,
 		AuthorizationTimeout: 5 * time.Minute,
@@ -48,11 +48,6 @@ func DefaultOAuthConfig() *OAuthConfig {
 // WithDefaults returns a new config with defaults applied for any unset fields
 func (c *OAuthConfig) WithDefaults() *OAuthConfig {
 	config := *c
-
-	// Set default scopes if none provided
-	if len(config.Scopes) == 0 {
-		config.Scopes = []string{"mcp:tools", "mcp:resources"}
-	}
 
 	// Set default timeout if not provided
 	if config.AuthorizationTimeout == 0 {
@@ -96,11 +91,6 @@ func (c *OAuthConfig) Validate() error {
 		return fmt.Errorf("HTTPS redirect URIs are not supported - callback server only runs on localhost with HTTP (use http://localhost:PORT/callback)")
 	} else {
 		return fmt.Errorf("redirect URI scheme must be http, got: %s (only http://localhost:PORT/callback is supported)", parsedURL.Scheme)
-	}
-
-	// Validate scopes are set (after defaults have been applied)
-	if len(c.Scopes) == 0 {
-		return fmt.Errorf("OAuth scopes are required")
 	}
 
 	// Validate timeout is set (after defaults have been applied)

--- a/internal/agent/oauth_config_test.go
+++ b/internal/agent/oauth_config_test.go
@@ -48,21 +48,13 @@ func TestOAuthConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty scopes fail validation",
+			name: "empty scopes are allowed",
 			config: &OAuthConfig{
-				Enabled:     true,
-				RedirectURL: "http://localhost:8765/callback",
-				Scopes:      []string{},
+				Enabled:              true,
+				RedirectURL:          "http://localhost:8765/callback",
+				Scopes:               []string{},
+				AuthorizationTimeout: 5 * time.Minute,
 			},
-			wantErr: true,
-		},
-		{
-			name: "empty scopes pass validation after WithDefaults",
-			config: (&OAuthConfig{
-				Enabled:     true,
-				RedirectURL: "http://localhost:8765/callback",
-				Scopes:      []string{},
-			}).WithDefaults(),
 			wantErr: false,
 		},
 		{
@@ -167,8 +159,8 @@ func TestDefaultOAuthConfig(t *testing.T) {
 		t.Error("Default config should have UsePKCE = true")
 	}
 
-	if len(config.Scopes) == 0 {
-		t.Error("Default config should have default scopes")
+	if len(config.Scopes) != 0 {
+		t.Error("Default config should have no scopes")
 	}
 
 	if config.UseOIDC {
@@ -189,7 +181,7 @@ func TestOAuthConfig_WithDefaults(t *testing.T) {
 			},
 			expected: &OAuthConfig{
 				Enabled:              true,
-				Scopes:               []string{"mcp:tools", "mcp:resources"},
+				Scopes:               []string{},
 				RedirectURL:          "http://localhost:8765/callback",
 				AuthorizationTimeout: 5 * time.Minute,
 			},
@@ -205,7 +197,7 @@ func TestOAuthConfig_WithDefaults(t *testing.T) {
 				Enabled:              true,
 				ClientID:             "custom-client",
 				RedirectURL:          "http://localhost:9999/callback",
-				Scopes:               []string{"mcp:tools", "mcp:resources"},
+				Scopes:               []string{},
 				AuthorizationTimeout: 5 * time.Minute,
 			},
 		},


### PR DESCRIPTION
## Summary

This PR removes the default MCP scopes from OAuth configuration and makes scopes completely optional. Previously, `mcp-debug` would always send `mcp:tools` and `mcp:resources` scopes by default, which doesn't make sense for all MCP servers.

## Changes

- **cmd/root.go**: Changed `--oauth-scopes` flag default from `mcp:tools,mcp:resources` to empty array
- **internal/agent/oauth_config.go**: 
  - Removed default scopes from `DefaultOAuthConfig()`
  - Removed auto-fill logic in `WithDefaults()` that added default scopes
  - Removed validation requiring scopes to be set
  - Updated comments to reflect optional scopes
- **internal/agent/oauth_config_test.go**: Updated tests to reflect new optional scope behavior
- **docs/usage.md**: Updated documentation to clearly state scopes are optional with examples

## Behavior Changes

**Before:**
- OAuth requests always included `mcp:tools,mcp:resources` scopes by default
- Users had to explicitly override to use different scopes
- Empty scopes would be auto-filled with defaults

**After:**
- No scopes are sent by default
- Users can optionally specify scopes via `--oauth-scopes` flag
- Empty scopes remain empty (no auto-fill)

## Testing

✅ All existing tests pass
✅ Updated tests to verify optional scope behavior
✅ Code formatted with `goimports` and `go fmt`

## Migration

This is a **breaking change** for users who relied on the default scopes being sent automatically. Users who need specific scopes should now explicitly set them:

```bash
# Before (implicit)
./mcp-debug --oauth --endpoint https://server.com/mcp

# After (explicit if needed)
./mcp-debug --oauth --oauth-scopes "mcp:tools,mcp:resources" --endpoint https://server.com/mcp
```