### PR TITLE
fix(oauth): correct UTF-8 encoding in browser success message

### DIFF
--- a/internal/agent/oauth_mcp.go
+++ b/internal/agent/oauth_mcp.go
@@ -267,8 +267,8 @@ func createCallbackHandler(logger *Logger, resultChan chan<- callbackResult) htt
 			logger.Warning("Callback received but already processed")
 		}
 
-		w.Header().Set("Content-Type", "text/html")
-		if _, err := w.Write([]byte(`<html><body><h1>✅ Authorization Successful!</h1><p>You can close this window.</p></body></html>`)); err != nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if _, err := w.Write([]byte(`<html><head><meta charset="utf-8"></head><body><h1>✅ Authorization Successful!</h1><p>You can close this window.</p></body></html>`)); err != nil {
 			logger.Warning("Failed to write response: %v", err)
 		}
 	}


### PR DESCRIPTION
## Problem

After successful OAuth authorization, the success message displayed in the browser showed garbled characters: `âœ…` instead of the intended checkmark emoji `✅`.

## Root Cause

The HTTP response was missing the charset declaration, causing browsers to incorrectly interpret UTF-8 encoded emoji bytes as Latin-1/ISO-8859-1 characters.

## Solution

This PR fixes the encoding issue by:
1. Setting the HTTP Content-Type header to `text/html; charset=utf-8`
2. Adding `<meta charset="utf-8">` to the HTML head section

## Testing

- ✅ All tests pass
- ✅ Code formatted with goimports and go fmt
- Manual testing: OAuth callback now displays the success message correctly with proper emoji rendering

## Changes

- Modified `internal/agent/oauth_mcp.go` to include proper UTF-8 encoding declarations