### PR TITLE
ci: switch CircleCI to cli flavour so releases ship binaries

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -21,6 +21,31 @@ workflows:
         # override their own `make test`. See devctl makefile gen and the
         # make-target-ci-interface ADR.
         test_target: test
+        # Cross-platform binaries attached to the GitHub Release by the
+        # upload-release-assets job below (cli flavour). yamllint disables the
+        # line-length rule for the 132-char matrix value.
+        # yamllint disable-line rule:line-length
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+        # The six-arch cross-compile is cold after every go.sum bump (the GOCACHE
+        # restore misses), so compile the architectures concurrently on a larger
+        # box instead of sequentially on 2 vCPUs. build_concurrency is opt-in in
+        # the orb because it only pays off at a bigger resource_class.
+        build_concurrency: auto
+        resource_class: large
         filters:
           tags:
             only: /^v.*/
+
+    # Attach the cross-platform go-build binaries to the GitHub Release on tag
+    # builds. The release itself is created by the repo's auto-release flow.
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: mcp-debug
+        requires:
+        - go-build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-# This script downloads the latest mcp-debug .tar.gz release archive by
-# querying the GitHub API for the latest tag, constructing the correct filename,
-# and extracting the binary. It avoids dependencies like jq.
+# This script downloads the latest mcp-debug binary by querying the GitHub API
+# for the latest release tag and fetching the matching per-platform asset
+# (mcp-debug-<os>-<arch>). It avoids dependencies like jq.
 
 # Helper function for logging
 info() {
@@ -11,7 +11,7 @@ info() {
 }
 
 # Check for required tools
-for tool in curl grep sed tar tr uname; do
+for tool in curl grep sed tr uname; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "[ERROR] '$tool' is not installed. Please install it to continue."
         exit 1
@@ -45,23 +45,18 @@ if [ -z "$LATEST_TAG" ]; then
 fi
 
 info "Latest version tag is $LATEST_TAG"
-VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
 
-# Construct the download URL for the .tar.gz archive
-ARCHIVE_NAME="mcp-debug_${VERSION}_${OS}_${ARCH}.tar.gz"
-DOWNLOAD_URL="https://github.com/giantswarm/mcp-debug/releases/download/${LATEST_TAG}/${ARCHIVE_NAME}"
+# Construct the download URL. Releases are built by the architect CircleCI
+# pipeline (cli flavour), which attaches a raw, per-platform binary named
+# mcp-debug-<os>-<arch> to the GitHub Release -- not a versioned tarball.
+BINARY_NAME="mcp-debug-${OS}-${ARCH}"
+DOWNLOAD_URL="https://github.com/giantswarm/mcp-debug/releases/download/${LATEST_TAG}/${BINARY_NAME}"
 
 info "Constructed download URL: $DOWNLOAD_URL"
 
-# Download the archive
-curl -L -o "${ARCHIVE_NAME}" "${DOWNLOAD_URL}"
+# Download the binary directly.
+curl -fL -o mcp-debug "${DOWNLOAD_URL}"
 info "Download complete."
-
-# Un-tar the archive to extract the binary and then clean up
-info "Extracting binary from ${ARCHIVE_NAME}..."
-tar -xzf "${ARCHIVE_NAME}" mcp-debug
-rm "${ARCHIVE_NAME}"
-info "Extraction complete."
 
 chmod +x mcp-debug
 info "Made binary executable."
@@ -69,4 +64,4 @@ info "Made binary executable."
 info "Installation successful! The 'mcp-debug' binary is now in your current directory."
 info "You can run it with: ./mcp-debug"
 info "For system-wide access, move it to a directory in your PATH, e.g.:"
-info "sudo mv mcp-debug /usr/local/bin/mcp-debug" 
+info "sudo mv mcp-debug /usr/local/bin/mcp-debug"


### PR DESCRIPTION
## Problem

mcp-debug's CircleCI was generated with the **generic** flavour, so the build pipeline only ran `go-build`. The `zz_generated.auto_release.yaml` flow creates a GitHub Release on every tag but relies on CircleCI's `upload-release-assets` job to attach binaries -- which the generic flavour does not emit. Result: every Release (e.g. `v0.0.108`) ships with **zero assets**, and `install.sh` (which downloaded a goreleaser-style `mcp-debug_<version>_<os>_<arch>.tar.gz`) had nothing to fetch.

## Proposed solution

- Switch `.circleci/workflows.yml` to the **cli** flavour: `go-build` cross-compiles the six-platform matrix (`linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64`) and `architect/upload-release-assets` attaches the raw per-platform binaries (`mcp-debug-<os>-<arch>`, plus SBOM `.bundle`s) to the Release on each `v*` tag.
- Update `install.sh` to fetch the raw `mcp-debug-<os>-<arch>` asset directly (no tarball, no extraction), matching the architect asset naming.

The matching `gen.flavours: generic -> cli` change lands in `giantswarm/github` (`repositories/team-bumblebee.yaml`) so align-files keeps the generated config in sync; this PR carries the regenerated config so it takes effect on the next release without waiting for an align-files sweep.

## Acceptance criteria

- [ ] CircleCI `go-build` is green on this PR.
- [ ] On the next tag, the GitHub Release carries `mcp-debug-<os>-<arch>` assets.
- [ ] `install.sh` downloads and installs the binary successfully.

Made with [Cursor](https://cursor.com)