### PR TITLE
fix(version): stamp the release version through pkg/project so released binaries stop reporting "dev"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
+# Build outputs and CI scratch files, all written next to the sources: the
+# devctl Makefile's mcp-debug-v<version>-<os>-<arch> and bin-dist/, the
+# architect CI's .ldflags, .platforms and mcp-debug-<os>-<arch> (six of them,
+# built concurrently). Untracked, any of these flips Go's VCS stamp to
+# vcs.modified=true and the binaries built after it report vX.Y.Z+dirty
+# (pkg/project reads that stamp when no version ldflag is injected).
 mcp-debug
+/mcp-debug-*
+/bin-dist/
+.ldflags
+.platforms
 dist/
 .cursor/mcp.json
 

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
-import "github.com/giantswarm/mcp-debug/cmd"
-
-// Version can be set during build with -ldflags
-var version = "dev"
+import (
+	"github.com/giantswarm/mcp-debug/cmd"
+	"github.com/giantswarm/mcp-debug/pkg/project"
+)
 
 func main() {
-	cmd.SetVersion(version)
+	cmd.SetVersion(project.Version())
 	cmd.Execute()
 }

--- a/pkg/project/doc.go
+++ b/pkg/project/doc.go
@@ -1,0 +1,4 @@
+// Package project exposes the build identifiers stamped into the binary at
+// link time (version, gitSHA, buildTimestamp). It has no dependencies so it
+// can be safely imported by main and any CLI command.
+package project

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,66 @@
+package project
+
+import "runtime/debug"
+
+// dev is the default for unset build identifiers. Local `go build`
+// invocations without ldflags keep this so `mcp-debug --version` stays
+// printable and `mcp-debug self-update` keeps refusing to replace a
+// development build.
+const dev = "dev"
+
+// devel is the module version runtime/debug reports for a build that carries
+// no resolvable VCS tag (no .git, or built outside a module checkout).
+const devel = "(devel)"
+
+// Build identifiers. The generated Makefile.gen.go.mk stamps all three via
+// `-X` ldflags. The architect-orb `go-build` job that produces the release
+// assets overrides `gitSHA` (from `CIRCLE_SHA1`) and `buildTimestamp` (UTC
+// build time) but does NOT inject `version`; there the version is derived at
+// runtime from the Go build info (see Version), which the toolchain stamps
+// from the VCS tag — a clean semver when the build sits exactly on a tag, as
+// release builds do since they run on the tagged commit.
+var (
+	version        = dev
+	gitSHA         = dev
+	buildTimestamp = "unknown"
+)
+
+// Version returns the best human-readable build identifier available, in
+// order: an explicitly injected `version` ldflag, the VCS version stamped into
+// the Go build info, the injected commit SHA, and finally the placeholder
+// "dev".
+func Version() string {
+	if version != dev && version != "" {
+		return version
+	}
+	if v := buildInfoVersion(); v != "" {
+		return v
+	}
+	if gitSHA != dev {
+		return gitSHA
+	}
+	return dev
+}
+
+// buildInfoVersion reads the main module version the Go toolchain embedded from
+// version control. It returns "" when no usable version is present — either no
+// build info, or the "(devel)" placeholder a tag-less build produces — so
+// Version can fall through to the next source.
+var buildInfoVersion = func() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	if v := info.Main.Version; v != "" && v != devel {
+		return v
+	}
+	return ""
+}
+
+// GitSHA returns the commit SHA the binary was built from, or "dev" when no
+// ldflag was injected.
+func GitSHA() string { return gitSHA }
+
+// BuildTimestamp returns the UTC build time in RFC 3339 format, or
+// "unknown" when no ldflag was injected.
+func BuildTimestamp() string { return buildTimestamp }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,0 +1,43 @@
+package project
+
+import "testing"
+
+func TestVersionFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		buildInfo string
+		gitSHA    string
+		want      string
+	}{
+		{"nothing available", "dev", "", "dev", "dev"},
+		{"explicit version ldflag wins", "v1.2.3", "v0.9.0", "abc1234", "v1.2.3"},
+		{"empty version ldflag falls through", "", "v1.2.3", "abc1234", "v1.2.3"},
+		{"build info supplies version", "dev", "v1.2.3", "abc1234", "v1.2.3"},
+		{"build info absent; sha fallback", "dev", "", "abc1234", "abc1234"},
+		{"build info beats sha", "dev", "v1.2.3", "abc1234", "v1.2.3"},
+	}
+
+	origVersion, origSHA, origBuildInfo := version, gitSHA, buildInfoVersion
+	t.Cleanup(func() { version, gitSHA, buildInfoVersion = origVersion, origSHA, origBuildInfo })
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version = tc.version
+			gitSHA = tc.gitSHA
+			buildInfoVersion = func() string { return tc.buildInfo }
+			if got := Version(); got != tc.want {
+				t.Errorf("Version() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccessors(t *testing.T) {
+	if GitSHA() == "" {
+		t.Error("GitSHA must not be empty")
+	}
+	if BuildTimestamp() == "" {
+		t.Error("BuildTimestamp must not be empty")
+	}
+}


### PR DESCRIPTION
## Problem

The published release binary of v0.0.130 (`mcp-debug-linux-amd64`) prints `mcp-debug version dev` for `--version`. As a consequence `mcp-debug self-update` in every released binary fails with `cannot self-update a development version`, and the MCP client announces `Version: "dev"` to servers.

## Cause

The generated `Makefile.gen.go.mk` stamps `-X '$(MODULE)/pkg/project.version=$(VERSION)'` (plus `pkg/project.buildTimestamp` and `pkg/project.gitSHA`), and the architect-orb `go-build` job that produces the release assets stamps `pkg/project.gitSHA` and `pkg/project.buildTimestamp`. mcp-debug had no `pkg/project` package: the version lived in `main.go` as `var version = "dev"`, so nothing ever stamped it.

## Fix

- Add `pkg/project` following the convention of the other Giant Swarm Go CLIs (muster, devctl): package-level `version`, `gitSHA`, `buildTimestamp` with exported getters, and a `Version()` that falls back to the VCS version the Go toolchain embeds in the build info when no `version` ldflag is injected. That fallback is the release path: the orb does not inject `version`, but it builds on the tagged commit, so the build info carries the clean tag.
- `main.go` passes `project.Version()` to `cmd.SetVersion`. The `cmd.SetVersion` API is unchanged.
- Unit tests for the fallback order.
- `.gitignore` covers the files the CI and the Makefile write next to the sources (`.ldflags`, `.platforms`, `mcp-debug-<os>-<arch>`, `mcp-debug-v<version>-<os>-<arch>`, `bin-dist/`). Go marks the tree dirty on any untracked file and `pkg/project` reads that VCS stamp on the release path, so without this the assets would report `vX.Y.Z+dirty` (agentlab v0.17.0/v0.17.1 did; mcp-kubernetes#604 and agentlab#75 carry the same ignores). Until architect-orb#924 ships the orb-side `version` stamp, the asset prints the tag with its `v` (`v0.0.131`); afterwards the bare `0.0.131`.

## Proof

```
$ CGO_ENABLED=0 go build -trimpath -ldflags "-X github.com/giantswarm/mcp-debug/pkg/project.version=v9.9.9" -o /tmp/mcp-debug-stamp .
$ /tmp/mcp-debug-stamp --version
mcp-debug version v9.9.9
$ /tmp/mcp-debug-stamp self-update
Current version: v9.9.9
Checking for updates...
Current version is the latest.

$ CGO_ENABLED=0 go build -trimpath -o /tmp/mcp-debug-unstamped .   # on the v0.0.130 commit, with this change uncommitted
$ /tmp/mcp-debug-unstamped --version
mcp-debug version v0.0.130+dirty
```

`go build ./... && go vet ./... && go test ./...` and `golangci-lint run ./...` pass.

After merge, the next auto-release's `mcp-debug-linux-amd64` asset should print its tag for `--version`; I will verify that on the release.

